### PR TITLE
Fix for Issue #5 (Hyperlinks in Logged In As section appear on one line) 

### DIFF
--- a/sass/_layout.sass
+++ b/sass/_layout.sass
@@ -85,6 +85,7 @@
     color: $text_color
     float: right
     margin-right: inherit
+    width: inherit
     a
       color: $link_color
 


### PR DESCRIPTION
Fix for Issue #5 (Hyperlinks in Logged In As section appear on one line) occurring in Chrome with long usernames
