### PR TITLE
splitleft and splitright div's overlap on viewing a user.

### DIFF
--- a/sass/_general_classes.sass
+++ b/sass/_general_classes.sass
@@ -32,7 +32,7 @@ p.subtitle
   margin: 0
 
 .splitcontentleft, .splitcontentright
-  width: 48%
+  width: 47%
 .splitcontentleft
   float: left
 .splitcontentright


### PR DESCRIPTION
To fix this, I just reduced the width of splitcontentleft and splitcontentright to 47%. I don't know how much of an impact it will have on the rest of the site, though.
